### PR TITLE
New dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk update && \
     curl-dev \
     geoip-dev \
     git \
+    grep \
     libxml2 \
     linux-headers \
     mariadb-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,50 @@
-FROM rails:4.2.5
+FROM ruby:2.3-alpine
 
-RUN \
-  curl -LOs https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
-  tar xjf phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
-  cp phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/local/bin/ && \
-  rm -r phantomjs-1.9.8-linux-x86_64 phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
-  curl -LOs http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz && \
+RUN apk add --no-cache \
+  build-base \
+  postgresql-dev \
+  git \
+  bash \
+  nodejs \
+  libxml2-dev libxslt-dev \
+  linux-headers \
+  && rm -rf /var/cache/apk/*
+
+RUN curl -Ls https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 \
+  | tar xjC /
+
+  # zcat phantomjs-1.9.8-linux-x86_64.tar.bz2 | tar -xzf - && \
+  # cp phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/local/bin/ && \
+  # rm -r phantomjs-1.9.8-linux-x86_64 phantomjs-1.9.8-linux-x86_64.tar.bz2
+
+RUN curl -LOs http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz && \
   gunzip GeoLiteCity.dat.gz && \
   mkdir -p /usr/share/GeoIP/ && \
   mv GeoLiteCity.dat /usr/share/GeoIP/GeoIPCity.dat
+
+ENV APP=/app
+ENV DOCKER=true
+RUN mkdir -p $APP
+WORKDIR $APP
+
+ENV BUNDLE_GEMFILE=/app/Gemfile \
+  BUNDLE_JOBS=8 \
+  BUNDLE_PATH=/bundle
+
+
+RUN gem install bundler \
+    && bundle config build.nokogiri --use-system-libraries
+
+# COPY Gemfile Gemfile.lock ./
+# RUN bundle install \
+    # && echo "Bundle install complete"
+
+# RUN RAILS_ENV=production bundle install --without development test --no-color --path /opt/app
+# COPY . $APP
+
+ENV PORT=3000
+
+EXPOSE $PORT
+
+ENTRYPOINT ["bundle", "exec"]
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,4 @@ ENV BUNDLE_GEMFILE=${APP}/Gemfile \
   BUNDLE_JOBS=8 \
   BUNDLE_PATH=/bundle
 
-RUN gem install bundler \
-    && bundle config build.nokogiri --use-system-libraries
-
+RUN gem install bundler

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@
 BUILDFLAGS="$@"
 
 echo "Building rails image"
-docker build $BUILDFLAGS -t "inquicker/rails-dev:latest" .
+# docker build $BUILDFLAGS -t "inquicker/rails-dev:latest" .
+docker build $BUILDFLAGS -t "mrinterweb/iq-rails:latest" .
 
 # docker push inquicker/rails-dev:latest

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BUILDFLAGS="$@"
+
+echo "Building rails image"
+docker build $BUILDFLAGS -t "inquicker/rails-dev:latest" .
+
+# docker push inquicker/rails-dev:latest

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,9 @@
 BUILDFLAGS="$@"
 
 echo "Building rails image"
-# docker build $BUILDFLAGS -t "inquicker/rails-dev:latest" .
-docker build $BUILDFLAGS -t "mrinterweb/iq-rails:latest" .
+IMAGE="inquicker/rails-dev:latest"
+# IMAGE="mrinterweb/iq-rails:latest"
 
-# docker push inquicker/rails-dev:latest
+docker build $BUILDFLAGS -t $IMAGE .
+docker push $IMAGE
+


### PR DESCRIPTION
The official rails docker image is deprecated and suggests to just create your own. I decided it would be best to base the image off ruby:2.3-alpine since docker for mac uses alpine as the host OS. This image has all the dependencies we need to install all the gems currently used in iqapp.

https://hub.docker.com/_/rails/
